### PR TITLE
Run Rust workflow on pull_request always

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,13 +7,6 @@ on:
     tags:
       - v*
   pull_request:
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain'
-      - '.github/workflows/rust.yml'
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
必須のworkflowにしていたが， #65 みたいなやつで困るので