### PR TITLE
Update actix-web to v4.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "GitHub notification manager"
 
 [dependencies]
 actix-service = "2.0.2"
-actix-web = "4.5.1"
+actix-web = "4.9.0"
 crypto-hashes = "0.10.0"
 futures = "0.3.30"
 hex = "0.4.3"


### PR DESCRIPTION
- #244 で上がっているが、これは sentry-actix が引き連れてきたバージョンで、lockfile しか更新されていなかった