### PR TITLE
fix: relax over-strict payload field types

### DIFF
--- a/src/github/common.rs
+++ b/src/github/common.rs
@@ -176,7 +176,7 @@ pub struct PullRequest {
     pub locked: bool,
     pub title: String,
     pub user: User,
-    pub body: String,
+    pub body: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub closed_at: Option<String>,
@@ -221,7 +221,7 @@ pub struct PullRequestHead {
     pub ref_: String,
     pub sha: String,
     pub user: User,
-    pub repo: Repository,
+    pub repo: Option<Repository>, // fork が消えていると null になる
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/github/common.rs
+++ b/src/github/common.rs
@@ -1,3 +1,4 @@
+use serde::de::IgnoredAny;
 use serde::Deserialize;
 use url::Url;
 
@@ -148,17 +149,17 @@ pub struct Issue {
     pub locked: bool,
     pub assignee: Option<User>,
     pub assignees: Vec<User>,
-    pub milestone: Option<()>,
+    pub milestone: Option<IgnoredAny>,
     pub comments: usize,
     pub created_at: String,
     pub updated_at: String,
     pub closed_at: Option<String>,
     pub author_association: String,
-    pub active_lock_reason: Option<()>,
+    pub active_lock_reason: Option<IgnoredAny>,
     pub body: Option<String>,
     pub reactions: Reactions,
     pub timeline_url: Url,
-    pub performed_via_github_app: Option<()>,
+    pub performed_via_github_app: Option<IgnoredAny>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -183,10 +184,10 @@ pub struct PullRequest {
     pub merge_commit_sha: Option<String>,
     pub assignee: Option<User>, // Issueと挙動が違う？
     pub assignees: Vec<User>,
-    pub requested_reviewers: Vec<User>, // TODO: teamの場合もある
-    pub requested_teams: Vec<()>,       // TODO: これは確実にteam
+    pub requested_reviewers: Vec<User>,   // TODO: teamの場合もある
+    pub requested_teams: Vec<IgnoredAny>, // TODO: これは確実にteam
     pub labels: Vec<Label>,
-    pub milestone: Option<()>,
+    pub milestone: Option<IgnoredAny>,
     pub draft: bool,
     pub commits_url: Url,
     pub review_comments_url: Url,
@@ -197,8 +198,8 @@ pub struct PullRequest {
     pub base: PullRequestBase,
     pub _links: PullRequestLinks,
     pub author_association: String,
-    pub auto_merge: Option<()>,
-    pub active_lock_reason: Option<()>,
+    pub auto_merge: Option<IgnoredAny>,
+    pub active_lock_reason: Option<IgnoredAny>,
     pub merged: Option<bool>,    // nullになりようがなくない？？？
     pub mergeable: Option<bool>, // ref: https://github.com/octokit/webhooks/blob/ce6ab8f2ca6c8358a415448f71e20d1d50d458f8/payload-schemas/api.github.com/common/pull-request.schema.json#L168-L170
     pub rebaseable: Option<bool>,
@@ -251,7 +252,7 @@ pub struct IssueComment {
     pub author_association: String,
     pub body: String,
     pub reactions: Reactions,
-    pub performed_via_github_app: Option<()>,
+    pub performed_via_github_app: Option<IgnoredAny>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -140,7 +140,7 @@ impl Payload {
             }
 
             Payload::IssueComment(icomment) => &icomment.comment.body,
-            Payload::PullRequest(pr) => &pr.pull_request.body,
+            Payload::PullRequest(pr) => pr.pull_request.body.as_deref().unwrap_or(""),
         }
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -178,9 +178,10 @@ impl TryFrom<&github::PullRequest> for slack::Message {
                         title = pr.title
                     ));
                     let title_link = Some(pr.html_url.clone());
-                    let fallback = format!("{title}\n{body}", title = pr.title, body = pr.body);
+                    let body = pr.body.as_deref().unwrap_or("");
+                    let fallback = format!("{title}\n{body}", title = pr.title);
 
-                    let mut text = pr.body.clone();
+                    let mut text = body.to_string();
                     if let Some(astr) = users2str(&pr.assignees, "\n", true) {
                         text += "\n*Assignees*\n";
                         text += &astr;


### PR DESCRIPTION
Fixes #311

payload の型が実際の webhook より厳しく、値が入ると deserialize が失敗して通知が飛ばなくなっていた。`Payload` は `#[serde(untagged)]` なので 1 フィールドの失敗で全 variant が不一致になり、400 を返して終わる。

## 使っていないフィールド → `serde::de::IgnoredAny`

`Option<()>` / `Vec<()>` は JSON の `null` / `[]` しか受け付けない。値を捨てたまま任意の型を受け付ける `IgnoredAny` にする。

- `Issue.milestone` / `PullRequest.milestone`
- `PullRequest.requested_teams` / `PullRequest.auto_merge`
- `Issue.active_lock_reason` / `PullRequest.active_lock_reason`
- `Issue.performed_via_github_app` / `IssueComment.performed_via_github_app`

## null になりうるフィールド → `Option`

- `PullRequest.body` — 説明なしで作られた PR。`Issue.body` は既に `Option<String>` なので、`Payload::body()` も Issues と同じく空文字へフォールバックさせる
- `PullRequestHead.repo` — fork が消えた PR

## 動作確認

本体を起動して `issues` / `issue_comment` / `pull_request` の payload を投げ、対象フィールドだけを 1 つずつ変えて比較した。

- 上記 10 フィールドに値を入れた payload: 修正前 **400** (通知処理に到達しない) → 修正後 **200** (到達する)
- 対象フィールドを入れない payload: 修正前後とも 200 で到達 (対照)

なお reviewdog が挙げている clippy 警告 (`to_string_trait_impl` / `dead_code`) は main 由来で、main と本 PR で警告の集合は一致している (本 PR で増えたものは無い)。

payload 単位の回帰テストは fixture が無いため #292 に委ねる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
