### PR TITLE
chore: update Rust to 1.90.0 and migrate to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hubhook"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 
 authors = ["sksat <sksat@arkedgespace.com>"]
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sksat/cargo-chef-docker:1.78.0-bullseye as chef
+FROM ghcr.io/sksat/cargo-chef-docker:1.90.0-bullseye as chef
 LABEL maintainer "sksat <sksat@arkedgespace.com>"
 
 WORKDIR build

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.90.0"

--- a/src/github/common.rs
+++ b/src/github/common.rs
@@ -1,5 +1,11 @@
-use serde::de::IgnoredAny;
+// GitHub webhook の payload schema をそのまま写した型定義。
+// octokit/webhooks の payload-schemas と突き合わせられることを優先し、
+// 現時点で読んでいないフィールドもスキーマの記述として残しているため、
+// このモジュールでは dead_code を許可する。
+#![allow(dead_code)]
+
 use serde::Deserialize;
+use serde::de::IgnoredAny;
 use url::Url;
 
 #[derive(Debug, Deserialize)]
@@ -300,8 +306,11 @@ impl<'a> From<&'a Label> for &'a str {
     }
 }
 
-impl ToString for &Label {
-    fn to_string(&self) -> String {
-        self.name.to_string()
+// Rule::match_query_vec の `T: ToString` 境界に &Label を渡すために必要。
+// Display を実装しておけば std のブランケット実装経由で
+// &Label: Display -> &Label: ToString が成り立つ。
+impl std::fmt::Display for Label {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.name)
     }
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -45,6 +45,8 @@ impl std::error::Error for DeserializeError {
     }
 }
 
+// payload schema の写しなので、読んでいないフィールドも残す
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct Issues {
     pub action: IssuesAction,
@@ -55,6 +57,8 @@ pub struct Issues {
     pub installation: common::InstallationLite,
 }
 
+// payload schema の写しなので、読んでいないフィールドも残す
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct PullRequest {
     pub action: PullRequestAction,
@@ -67,6 +71,8 @@ pub struct PullRequest {
 }
 
 // Issue Comment & Pull-Request Comment
+// payload schema の写しなので、読んでいないフィールドも残す
+#[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 pub struct IssueComment {
     pub action: IssueCommentAction,
@@ -79,6 +85,8 @@ pub struct IssueComment {
 }
 
 impl IssueComment {
+    // issue_comment と PR comment の区別に使う想定で残している
+    #[allow(dead_code)]
     pub fn is_pull_request(&self) -> bool {
         self.issue.is_pull_request()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use regex::RegexBuilder;
 
 use actix_web::error::ErrorBadRequest;
-use actix_web::{web, App, Error, FromRequest, HttpRequest, HttpResponse, HttpServer, Result};
+use actix_web::{App, Error, FromRequest, HttpRequest, HttpResponse, HttpServer, Result, web};
 
 use futures::future::{Future, FutureExt};
 use futures::stream::TryStreamExt;
@@ -163,6 +163,12 @@ impl FromRequest for Data {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
+    // SAFETY: actix のランタイムはカレントスレッド上で動いており、この時点では
+    // まだワーカースレッドも sentry の転送スレッドも生成されていないため、
+    // 環境変数の書き込みが他スレッドの読み取りと競合することはない。
+    // sentry::init はスレッドを立てるので、必ずそれより前に置くこと。
+    unsafe { std::env::set_var("RUST_BACKTRACE", "1") };
+
     let opt = Opt::from_args();
 
     let _guard = sentry::init((
@@ -172,7 +178,6 @@ async fn main() -> std::io::Result<()> {
             ..Default::default()
         },
     ));
-    std::env::set_var("RUST_BACKTRACE", "1");
 
     let port = opt.hubhook_port;
 

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -26,6 +26,8 @@ pub struct Attachment {
     pub color: Option<Color>,
 }
 
+// Slack attachment の色パレット。現時点で使っていない色も定義として残す
+#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Color {
@@ -43,6 +45,7 @@ pub enum Color {
 }
 
 impl Message {
+    #[allow(dead_code)]
     pub fn from_string(text: String) -> Self {
         Self {
             text,


### PR DESCRIPTION
Rust のバージョンアップと edition 2024 移行。sentry のバージョンアップ (#278) の前提。

## なぜ必要か

依存更新系の PR がすべて落ちていた根本原因は、`rust-toolchain` が 1.78.0 に固定されていることでした。

- #278 (sentry 0.34 → 0.49): `digest 0.11.3` の manifest を parse できず ``feature `edition2024` is required`` で cargo がエラー
- #307 (actix-web 4.15): 同じ理由で `chacha20 0.10.2` が parse できない
- #264 / #252 (toolchain 自体の更新): cargo は通るが、新しい rustc/clippy が出す警告 17 件 (× bin/test = 34 件) を reviewdog が diff 外の行に post しようとして clippy ジョブが exit 1

つまり **toolchain を上げないと依存更新が通らず、警告を消さないと toolchain 更新自体が通らない** という状態でした。この PR で両方を外します。

## 変更点

### `chore(deps): update Rust to 1.90.0`

- `rust-toolchain`: 1.78.0 → 1.90.0
- `Dockerfile`: `cargo-chef-docker:1.78.0-bullseye` → `1.90.0-bullseye`

`cargo-chef-docker` は **1.90.0-bullseye が最新の公開タグ**で、1.91 以降は publish されていません (ghcr の manifest API で確認)。Renovate の #252 は toolchain だけ 1.98.1 に上げるため docker build 中に rustup が toolchain を追加取得しますが、この PR では両者を 1.90.0 に揃えて追加取得を避けています。1.85 以降なので edition 2024 も `edition2024` 要求の依存も問題なく通ります。

あわせて新しい clippy/rustc の警告を解消:

- `clippy::to_string_trait_impl` — `impl ToString for &Label` をやめて `impl Display for Label` に。`Rule::match_query_vec` の `T: ToString` 境界には std のブランケット実装 (`&Label: Display` → `&Label: ToString`) 経由で引き続き適合します
- `dead_code` — payload schema の写しである型は、octokit の payload-schemas と突き合わせられるよう未使用フィールドも残す方針なので `#[allow(dead_code)]` + 理由コメントで抑制

### `chore: migrate to Rust 2024 edition`

`cargo fix --edition` が出した変更は 1 箇所だけで、edition 2024 で `std::env::set_var` が unsafe fn になる点です。

cargo fix は `sentry::init` の**後ろ**に `unsafe` ブロックと `// FIXME: Audit that the environment access only happens in single-threaded code.` を残しますが、その位置では sentry の転送スレッドが既に立っているため「single-threaded である」と言えません。スレッドを一つも立てていない `main` の先頭に移し、SAFETY コメントで根拠を書いています。

`tail_expr_drop_order` の警告が `main.rs` に 2 件出ますが、どちらも sentry の `ClientInitGuard` と `error!` 引数の一時変数で、副作用の順序に依存していないため影響しません。

## 確認したこと

- `cargo clippy --all-targets` → **警告 0 件**
- `cargo test` → 5 passed
- `cargo fmt --check` → クリーン (import の並び順は style_edition 2024 に追従)

## この後

マージ後に #278 を rebase すれば sentry 0.49 が通るはずです。#307 / #268 も同様に外れます。#252 / #264 はこの PR で内容が置き換わるので close できます。
