### PR TITLE
chore: bump rust to 1.97.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/sksat/cargo-chef-docker:1.90.0-bullseye as chef
+FROM ghcr.io/sksat/cargo-chef-docker:1.97.1-bookworm as chef
 LABEL maintainer "sksat <sksat@arkedgespace.com>"
 
 WORKDIR build

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90.0"
+channel = "1.97.1"


### PR DESCRIPTION
rust を 1.90.0 → **1.97.1** に上げる。

## なぜ 1.97.1 か (最新ではない)

- **1.98.0 は飛ばす。** boxed async service で vtable が壊れる miscompile がある ([rust-lang/rust#161441](https://github.com/rust-lang/rust/issues/161441))。actix-web がとる形なので、このリポジトリは踏みうる
- **1.98.1 はまだ選べない。** 公式 docker image が存在しない (`rust:1.98.1` は Docker Hub に無く、1.98.0 まで)。cargo-chef-docker は「公式イメージがある版」しか作れないため、追従できない

影響を受けない最新版が 1.97.1。

## base image の suffix も変える (bullseye → bookworm)

**bullseye (Debian 11) は EOL。** セキュリティ更新が来ないものをビルダーに使い続けるべきではないので、これは仕方なく変えるのではなく、そもそも離れるべきだった。

そのため cargo-chef-docker も **1.90.0 を最後に bullseye 向けを作っていない** (1.91.0 以降の `BASE_IMGS` は slim / trixie / slim-trixie / bookworm / slim-bookworm)。`1.97.1-bullseye` を待っても出てこない。

**bookworm を選んだ理由**は最終段の `gcr.io/distroless/cc` との組み合わせ。pin している digest は中身が **trixie** で作られている (image config の history が `bazel build @trixie//... gcc-14-base`)。glibc は「古い方で build した binary が新しい runtime で動く」前方互換なので、bookworm builder + trixie runtime は成立する。もともと bullseye builder + trixie runtime という skew だったので、builder の世代を 1 つ上げるだけになる。

trixie にすると runtime と同世代で揃うが、distroless の pin が古い世代に戻ったときに壊れる余地が残るので選んでいない。

## 確認したこと

| | 結果 |
|---|---|
| `cargo clippy --all-targets -- -D warnings` | 警告 0 |
| `cargo test` | 59 passed |
| `cargo fmt --check` | OK |
| `cargo build --release` | OK |
| container build (podman) | OK |
| binary が distroless 上で起動するか | OK (引数検証まで到達) |
| builder の rustc | `1.97.1 (8bab26f4f 2026-07-14)` = pin と一致 |

7 版ぶんの飛びなので clippy の新しい lint を心配したが、追加の修正は要らなかった。builder の rustc が pin と一致するので、docker build 中に rustup が toolchain を取り直すことも無い。

## 残ること

renovate の #264 / #252 は 1.98.1 を提案しており、公式イメージが出るまで赤いまま残る。出たら 1.98.1 に上げられる (1.98.0 の miscompile はそこで解消される見込み)。
