### PR TITLE
fix: verify webhook signatures in constant time, unblock hmac 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +676,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1020,11 +1036,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1992,7 +2008,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2271,7 +2287,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3328,7 +3344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,24 +327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.1",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -539,15 +521,6 @@ checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
@@ -566,36 +539,11 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "crypto-hashes"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb285fe0bfe750b38baf57d8fa8205a4d93860c54f614515c18dbf5faf8cda33"
-dependencies = [
- "blake2",
- "digest 0.10.7",
- "groestl",
- "ripemd",
- "sha2",
- "sha3",
- "whirlpool",
 ]
 
 [[package]]
@@ -658,24 +606,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 
@@ -903,16 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,15 +883,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "groestl"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343cfc165f92a988fd60292f7a0bfde4352a5a0beff9fbec29251ca4e9676e4d"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "h2"
@@ -1040,7 +958,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.3",
+ "digest",
 ]
 
 [[package]]
@@ -1116,7 +1034,6 @@ version = "0.5.0"
 dependencies = [
  "actix-service",
  "actix-web",
- "crypto-hashes",
  "futures",
  "hex",
  "hmac",
@@ -1127,6 +1044,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "sha2",
  "structopt",
  "tokio",
  "tracing",
@@ -1420,15 +1338,6 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2191,15 +2100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2580,29 +2480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.1",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3311,15 +3201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "whirlpool"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ae50671d985c15b3214c7d969b8b520759fb3c8682444bec15ef775335a05c"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ description = "GitHub notification manager"
 [dependencies]
 actix-service = "2.0.2"
 actix-web = "4.9.0"
-crypto-hashes = "0.10.0"
 futures = "0.3.30"
 hex = "0.4.3"
 hmac = "0.13.0"
@@ -23,6 +22,9 @@ sentry-actix = "0.49.0"
 serde = "1.0.200"
 serde_json = "1.0.116"
 serde_path_to_error = "0.1.20"
+# hmac と digest の世代を揃える必要があるので直接依存にする
+# (crypto-hashes メタクレートは 2021 年から更新が無く sha2 0.10 で止まっている)
+sha2 = "0.11.0"
 structopt = "0.3.26"
 # team ごとの取得を 1 本にまとめるための非同期 Mutex だけを使う。
 # actix / reqwest 経由ですでに依存ツリーに入っている。

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ actix-web = "4.9.0"
 crypto-hashes = "0.10.0"
 futures = "0.3.30"
 hex = "0.4.3"
-hmac = "0.12.1"
+hmac = "0.13.0"
 regex = "1.10.4"
 reqwest = { version = "0.13.0", features = ["json"] }
 sentry = "0.49.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ use futures::stream::TryStreamExt;
 
 use tracing::{debug, error, info, warn};
 
-use crypto_hashes::sha2::Sha256;
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -139,13 +139,8 @@ impl FromRequest for Data {
                 .await;
             let p: Vec<u8> = p.unwrap();
 
-            let webhook_secret = &opt.webhook_secret.as_bytes();
-            let mut mac = HmacSha256::new_from_slice(webhook_secret).unwrap();
-            mac.update(&p);
-            let result = mac.finalize();
-
             // validate signature
-            if !compare_slice(&sig256, &result.into_bytes()) {
+            if !verify_signature(opt.webhook_secret.as_bytes(), &p, &sig256) {
                 error!("signature mismatch");
                 if !opt.debug {
                     return Err(ErrorBadRequest("signature mismatch!"));
@@ -452,17 +447,104 @@ async fn post_test(opt: &Opt, payload: &github::Payload) {
         .await;
 }
 
-fn compare_slice(a: &[u8], b: &[u8]) -> bool {
-    use std::cmp::Ordering;
+/// webhook の署名 (`X-Hub-Signature-256`) を検証する。
+///
+/// 比較は hmac の [`Mac::verify_slice`] に任せる。定数時間で比較されるので、
+/// 一致する先頭バイト数が処理時間に出ない。自前で 1 バイトずつ比較して
+/// 不一致で抜けると、その時間差から署名を 1 バイトずつ当てられてしまう。
+fn verify_signature(secret: &[u8], body: &[u8], signature: &[u8]) -> bool {
+    // HMAC の鍵は任意長を受け付けるので、この unwrap は落ちない
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(body);
 
-    if a.len() != b.len() {
-        return false;
+    mac.verify_slice(signature).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GitHub のドキュメントに載っている検証用の値。
+    ///
+    /// <https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries>
+    const SECRET: &[u8] = b"It's a Secret to Everybody";
+    const BODY: &[u8] = b"Hello, World!";
+    const SIGNATURE: &str = "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+
+    fn sig(hex_str: &str) -> Vec<u8> {
+        hex::decode(hex_str).expect("hex が壊れている")
     }
-    for (ai, bi) in a.iter().zip(b.iter()) {
-        match ai.cmp(bi) {
-            Ordering::Equal => continue,
-            _ => return false,
-        }
+
+    /// 正しい署名を受け入れること。
+    ///
+    /// ここが壊れると全部の webhook が弾かれて通知が止まる。
+    #[test]
+    fn correct_signature_is_accepted() {
+        assert!(verify_signature(SECRET, BODY, &sig(SIGNATURE)));
     }
-    true
+
+    /// 署名が違えば弾くこと。
+    ///
+    /// ここが壊れると誰でも偽の webhook を投げられる。
+    #[test]
+    fn wrong_signature_is_rejected() {
+        // 末尾 1 バイトだけ変える
+        let mut bad = sig(SIGNATURE);
+        *bad.last_mut().unwrap() ^= 0x01;
+        assert!(!verify_signature(SECRET, BODY, &bad));
+
+        // 先頭 1 バイトだけ変える (定数時間比較なので位置に関係なく弾く)
+        let mut bad = sig(SIGNATURE);
+        bad[0] ^= 0x01;
+        assert!(!verify_signature(SECRET, BODY, &bad));
+    }
+
+    /// 本文が変わっていれば弾くこと。
+    #[test]
+    fn tampered_body_is_rejected() {
+        assert!(!verify_signature(SECRET, b"Hello, World?", &sig(SIGNATURE)));
+    }
+
+    /// 鍵が違えば弾くこと。
+    #[test]
+    fn wrong_secret_is_rejected() {
+        assert!(!verify_signature(b"wrong secret", BODY, &sig(SIGNATURE)));
+    }
+
+    /// 長さが違う署名を弾くこと。
+    ///
+    /// 短い署名を「一致する分だけ」で通してしまうと、1 バイトの署名で
+    /// 通過できてしまう。
+    #[test]
+    fn wrong_length_signature_is_rejected() {
+        let full = sig(SIGNATURE);
+
+        assert!(!verify_signature(SECRET, BODY, &[]), "空の署名を通している");
+        assert!(
+            !verify_signature(SECRET, BODY, &full[..1]),
+            "先頭 1 バイトだけの署名を通している"
+        );
+        assert!(
+            !verify_signature(SECRET, BODY, &full[..full.len() - 1]),
+            "1 バイト短い署名を通している"
+        );
+
+        let mut longer = full.clone();
+        longer.push(0);
+        assert!(
+            !verify_signature(SECRET, BODY, &longer),
+            "1 バイト長い署名を通している"
+        );
+    }
+
+    /// 空の本文でも検証できること (本文なしのイベントは存在する)。
+    #[test]
+    fn empty_body_is_verified() {
+        let mut mac = HmacSha256::new_from_slice(SECRET).unwrap();
+        mac.update(b"");
+        let expected = mac.finalize().into_bytes();
+
+        assert!(verify_signature(SECRET, b"", &expected));
+        assert!(!verify_signature(SECRET, b"", &sig(SIGNATURE)));
+    }
 }


### PR DESCRIPTION
renovate の #329 (hmac 0.13.0) が CI で落ちていた。これを通した上に、同じ箇所で見つかった問題を直す。**#329 を置き換える** (バージョン上げだけに収まらないので、renovate に上書きされないよう別ブランチにした)。

## なぜ落ちていたか

hmac 0.13 は digest 0.11 を要求する。一方 `Sha256` は `crypto-hashes` 経由で取っていて、そちらは sha2 0.10 (= digest 0.10) で止まっている。世代が噛み合わず trait bound が 4 つ壊れていた。

```
error[E0277]: the trait bound `CoreWrapper<...>: CoreProxy` is not satisfied
error[E0277]: ... `BlockSizeUser` is not satisfied
error[E0277]: ... `FixedOutput` is not satisfied
error[E0277]: ... `HashMarker` is not satisfied
error[E0599]: no associated function named `new_from_slice` found for struct `Hmac<D>`
```

## crypto-hashes を外して sha2 を直接依存にする

`crypto-hashes` は **2021-12-10 から更新が無く**、このリポジトリは `crypto_hashes::sha2::Sha256` しか使っていない。上げようがないメタクレートを挟んでいるだけなので外し、`sha2 = "0.11.0"` を直接依存にした。

結果として **digest 0.10 が依存ツリーから消え**、世代の重複自体が無くなった。

| | before | after |
|---|---|---|
| hmac | 0.12.1 | 0.13.0 |
| sha2 | 0.10.9 (crypto-hashes 経由) | 0.11.0 (直接) |
| digest | 0.10.7 と 0.11.3 が同居 | 0.11.3 のみ |

hmac 0.13 では `new_from_slice` が `Mac` 経由で入らなくなったので、`KeyInit` を import している。

## 署名比較を定数時間にする

同じ関数にあった自前の `compare_slice` は**最初の不一致で `return` していたので定数時間ではない**。一致する先頭バイト数が処理時間に出るため、その差から署名を 1 バイトずつ当てられる。

hmac の `Mac::verify_slice` は定数時間で比較するので、そちらに任せて `compare_slice` を削除した。

## 署名検証のテストを足す

暗号の要なのに**テストが 1 件も無く**、壊しても気付けない状態だった。検証部分を `verify_signature` に切り出し、[GitHub のドキュメントに載っている検証用のベクタ](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)で固定した。

- 正しい署名を通すこと (壊れると全 webhook が弾かれて通知が止まる)
- 署名 / 本文 / 鍵のどれかが違えば弾くこと (壊れると誰でも偽の webhook を投げられる)
- 長さが違う署名を弾くこと — 空・1 バイト・1 バイト短い・1 バイト長い

長さの確認を入れたのは、短い署名を「一致する分だけ」で通す実装だと 1 バイトの署名で通過できてしまうため。

各テストは検証を常に true / 常に false に置き換えて、実際に落ちることを確認している。

## test

88 passed (+6) / clippy 警告 0 / release build OK
