### PR TITLE
chore: publish the image to GHCR instead of ECR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -14,8 +14,8 @@ on:
   merge_group:
 
 permissions:
-  id-token: write
-  contents: write
+  contents: read
+  packages: write
 
 jobs:
   build:
@@ -33,26 +33,25 @@ jobs:
           type=ref,event=branch
           type=ref,event=pr
           type=sha
-        images: ${{ secrets.ECR_URL }}/${{ github.repository }}
+        images: ghcr.io/${{ github.repository }}
 
     - name: Set up Buildx
       uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-    - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      with:
-        role-to-assume: ${{ secrets.IAM_ROLE }}
-        aws-region: ap-northeast-1
-    - name: Login to Amazon ECR
+    # push は main と tag のときだけ。PR と merge_group はビルドの確認だけする
+    - name: Login to GitHub Container Registry
+      if: github.event_name == 'push'
       uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
-        registry: ${{ secrets.ECR_URL }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and Push
       uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         context: .
-        push: true
+        push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha


### PR DESCRIPTION
ECR への push をやめて GHCR に出す。**これまで GHCR には出していなかった** (push 先は ECR だけだった)。

GHCR なら AWS の認証も `ECR_URL` / `IAM_ROLE` の secret も要らず、`GITHUB_TOKEN` で足りる。OIDC 用の `id-token: write` のかわりに `packages: write` を持つ。

push するのは main と tag のときだけにした。PR と `merge_group` はビルドの確認だけにとどめる。GHCR には ECR のような lifecycle policy が無いので、PR ごとに push するとタグが溜まり続ける (PR でも push したいなら `push:` の条件を外すだけ)。

job 名 (`build`) は変えていないので required check の設定はそのまま。

`actionlint` OK
