### PR TITLE
feat: show who did it in the attachment footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ HTTP 200 + `ok: false` で返すので、応答本文を見て判定している
 Assignees は `Assignees: a, b, c` の 1 行にまとめる (1 人 1 行だと縦に
 伸びて本文が見えなくなる)。
 
+attachment の footer には**操作した人** (sender) の login とアイコンを出す。
+issue の作成者ではないので、コメントなら作者ではなくコメントした人になる。
+footer は mrkdwn が効かないのでリンクにはならない。
+
 ### Notified events
 
 `X-GitHub-Event` のうち以下を扱う。

--- a/src/message.rs
+++ b/src/message.rs
@@ -110,6 +110,17 @@ fn body_text(body: &str, assignees: &[github::common::User]) -> Option<String> {
     (!text.trim().is_empty()).then_some(text)
 }
 
+/// 誰の操作かを footer に出す (#289)。
+///
+/// アイコンも添えると一目で分かる。footer は mrkdwn が効かないので、
+/// login をそのまま置く (リンクにはできない)。
+fn sender_footer(sender: &github::common::User) -> slack::Footer {
+    slack::Footer {
+        footer: sender.login.clone(),
+        footer_icon: Some(sender.avatar_url.clone()),
+    }
+}
+
 /// attachment の本文。markdown ブロックと、退避用の mrkdwn を組にする。
 fn body_content(body: &str, assignees: &[github::common::User]) -> slack::Body {
     slack::Body::new(body_blocks(body, assignees), body_text(body, assignees))
@@ -180,6 +191,7 @@ impl TryFrom<&github::Issues> for slack::Message {
                         title,
                         title_link,
                         fallback,
+                        footer: Some(sender_footer(&issues.sender)),
                         body: body_content(issue.body.as_deref().unwrap_or(""), &issue.assignees),
                         color,
                     }
@@ -222,6 +234,7 @@ impl TryFrom<&github::Issues> for slack::Message {
                         title,
                         title_link,
                         fallback,
+                        footer: Some(sender_footer(&issues.sender)),
                         body: body_content("", assignees),
                         color,
                     }
@@ -266,6 +279,7 @@ impl TryFrom<&github::PullRequest> for slack::Message {
                         title,
                         title_link,
                         fallback,
+                        footer: Some(sender_footer(&pull_request.sender)),
                         body: body_content(body, &pr.assignees),
                         color,
                     }
@@ -309,6 +323,7 @@ impl TryFrom<&github::PullRequest> for slack::Message {
                         title,
                         title_link,
                         fallback: pr.title.to_string(),
+                        footer: Some(sender_footer(&pull_request.sender)),
                         body: body_content(pr.body.as_deref().unwrap_or(""), &[]),
                         // 「対応してほしい」通知なので opened / assigned とは色を変える
                         color: Some(slack::Color::Warning),
@@ -345,6 +360,7 @@ impl TryFrom<&github::PullRequest> for slack::Message {
                         title,
                         title_link,
                         fallback: pr.title.to_string(),
+                        footer: Some(sender_footer(&pull_request.sender)),
                         body: body_content("", assignees),
                         color,
                     }
@@ -387,6 +403,7 @@ impl TryFrom<&github::IssueComment> for slack::Message {
                     title: None,
                     title_link: None,
                     fallback: comment.body.clone(),
+                    footer: Some(sender_footer(&issue_comment.sender)),
                     body: body_content(&comment.body, &[]),
                     color,
                 };
@@ -450,6 +467,7 @@ impl TryFrom<&github::PullRequestReview> for slack::Message {
             title: None,
             title_link: None,
             fallback: attach_text.clone(),
+            footer: Some(sender_footer(&review.sender)),
             body: body_content(&attach_text, &[]),
             color: Some(color),
         };
@@ -494,6 +512,7 @@ impl TryFrom<&github::PullRequestReviewComment> for slack::Message {
             title: Some(comment.path.clone()),
             title_link: Some(comment.html_url.clone()),
             fallback: comment.body.clone(),
+            footer: Some(sender_footer(&review_comment.sender)),
             body: body_content(&comment.body, &[]),
             color: Some(slack::Color::Comment),
         };
@@ -653,6 +672,28 @@ mod tests {
             body.contains("[Codertocat](https://github.com/Codertocat)"),
             "リンクが Markdown でない: {body}"
         );
+    }
+
+    /// footer に sender と avatar が出ること (#289)。
+    ///
+    /// issue の作成者ではなく**操作した人**を出す。comment なら
+    /// コメントした人で、issue の作者とは別人になる。
+    #[test]
+    fn footer_shows_the_sender() {
+        let payload = de(
+            "pull_request_review_comment",
+            "pull_request_review_comment.created.with-organization.json",
+        );
+        let sender = payload.sender().login.clone();
+
+        let msg = slack::Message::try_from(&payload).expect("通知されるべき");
+        let footer = msg.attachments.as_ref().unwrap()[0]
+            .footer
+            .as_ref()
+            .expect("footer が無い");
+
+        assert_eq!(footer.footer, sender);
+        assert!(footer.footer_icon.is_some(), "avatar が無い");
     }
 
     /// 本文が無いときに Assignees の前で空行を作らないこと。

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -142,8 +142,25 @@ pub struct Attachment {
     pub title_link: Option<url::Url>,
     pub fallback: String,
     pub color: Option<Color>,
+    /// 誰の操作かを小さく出す
+    #[serde(flatten)]
+    pub footer: Option<Footer>,
     #[serde(flatten)]
     pub body: Body,
+}
+
+/// attachment の footer。
+///
+/// mrkdwn は効かないので素のテキスト (`mrkdwn_in` に footer は入れられない)。
+/// 300 文字までで、狭い画面ではさらに切られる。
+/// `footer_icon` は footer があるときだけ効き、16x16 で描画される。
+///
+/// <https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments>
+#[derive(Debug, Serialize)]
+pub struct Footer {
+    pub footer: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer_icon: Option<url::Url>,
 }
 
 /// attachment の本文。
@@ -424,8 +441,16 @@ mod tests {
             title_link: None,
             fallback: "fallback".to_string(),
             color: None,
+            footer: None,
             body,
         }
+    }
+
+    fn payload_with_footer(body: Body, footer: Option<Footer>) -> MessagePayload {
+        let mut p = payload(body);
+        p.attachments.as_mut().unwrap()[0].footer = footer;
+
+        p
     }
 
     fn payload(body: Body) -> MessagePayload {
@@ -625,6 +650,38 @@ mod tests {
         // 退避すると表現が変わることも言えていること
         let fallback = payload(blocks("## body", Some("body"))).into_text_fallback();
         assert_eq!(fallback.body_kind(), "attachment text");
+    }
+
+    /// footer が `footer` / `footer_icon` として出ること。
+    ///
+    /// `Option` を flatten しているので、直列化の形を確かめておく。
+    #[test]
+    fn footer_is_flattened() {
+        let footer = Footer {
+            footer: "sksat".to_string(),
+            footer_icon: Some("https://example.com/avatar.png".parse().unwrap()),
+        };
+
+        let json = serde_json::to_value(payload_with_footer(blocks("## body", None), Some(footer)))
+            .expect("直列化に失敗");
+        let a = &json["attachments"][0];
+
+        assert_eq!(a["footer"], "sksat", "{a}");
+        assert_eq!(a["footer_icon"], "https://example.com/avatar.png", "{a}");
+    }
+
+    /// footer が無いときは何も出ないこと。
+    #[test]
+    fn no_footer_sends_nothing() {
+        let json = serde_json::to_value(payload_with_footer(blocks("## body", None), None))
+            .expect("直列化に失敗");
+        let a = &json["attachments"][0];
+
+        assert!(a.get("footer").is_none(), "footer が入っている: {a}");
+        assert!(
+            a.get("footer_icon").is_none(),
+            "footer_icon が入っている: {a}"
+        );
     }
 
     /// blocks 由来のエラーで、かつ blocks を持つときだけ再送すること。


### PR DESCRIPTION
closes #289

attachment に footer を付けて、**操作した人 (sender)** の login とアイコンを出す。アイコンがあると誰か一目で分かる。

issue の作成者ではなく sender を出す。comment ならコメントした人で、issue の作者とは別人になる。

footer は mrkdwn が効かない (`mrkdwn_in` に footer は入れられない) ので login をそのまま置く。リンクにはできない。`footer_icon` は footer があるときだけ効き、16x16 で描画される。

## test

93 passed / clippy 警告 0

`Option<Footer>` を `flatten` しているので、`footer` / `footer_icon` として出ること・footer が無いときは何も出ないことを JSON で確かめている。sender を出さないように戻すと落ちることも確認済み。
