### PR TITLE
fix: make logs usable for analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ SENTRY_DSN=''
 # team メンションを展開するための token (省略可, #286)
 # 未設定なら team メンションは展開されない
 GITHUB_TOKEN=''
+# ログのレベルとフィルタ (省略可, 既定は info)
+# 例: RUST_LOG='hubhook=debug'
+RUST_LOG=''

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,6 +1409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,10 +2946,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,5 @@ structopt = "0.3.26"
 # actix / reqwest 経由ですでに依存ツリーに入っている。
 tokio = { version = "1.53.1", features = ["sync"] }
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = { version = "2.5.0", features = ["serde"]}

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ for a release.
 |`SENTRY_DSN`|Sentry DSN|
 |`GITHUB_TOKEN`|used to expand team mentions (optional)|
 |`CONFIG_PATH`|where the config lives (optional, defaults to `/config/config.json`)|
+|`RUST_LOG`|log level and filter (optional, defaults to `info`)|
 
-Everything but the last two is required. `docker-compose.yml` and
-`.env.example` are set up for running it locally.
+Only `HUBHOOK_PORT`, `SLACK_TOKEN`, `WEBHOOK_SECRET` and `SENTRY_DSN` are
+required. `docker-compose.yml` and `.env.example` are set up for running it
+locally.
 
 ## Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - WEBHOOK_SECRET=${WEBHOOK_SECRET}
       - SENTRY_DSN=${SENTRY_DSN}
       - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - RUST_LOG=${RUST_LOG}
     ports:
       - 8080:${HUBHOOK_PORT}
     volumes:

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,12 +189,30 @@ async fn main() -> std::io::Result<()> {
 
     let port = opt.hubhook_port;
 
-    let level = if opt.debug {
-        tracing::Level::DEBUG
-    } else {
-        tracing::Level::WARN
+    // レベルを固定すると、後から「なぜ通知が飛ばなかったか」を追うために
+    // 再起動が要る。RUST_LOG で上書きできるようにしておく。
+    // 既定は info。warn 止めだと通知が飛んだこと自体が残らない。
+    let default = if opt.debug { "debug" } else { "info" };
+    let filter = match std::env::var("RUST_LOG") {
+        // 壊れた RUST_LOG で黙って既定に落ちると、レベルを変えたつもりで
+        // 変わっていないことに気付けない。まだ subscriber が無いので stderr に出す。
+        // docker-compose で `RUST_LOG=${RUST_LOG}` と書くと、未設定でも空文字が
+        // 入って Some("") になる。空の EnvFilter は directive を持たないので
+        // 何も出なくなってしまう。未設定として扱う。
+        Ok(spec) if spec.is_empty() => tracing_subscriber::EnvFilter::new(default),
+        Ok(spec) => tracing_subscriber::EnvFilter::try_new(&spec).unwrap_or_else(|e| {
+            eprintln!("invalid RUST_LOG ({spec:?}), falling back to {default}: {e}");
+            tracing_subscriber::EnvFilter::new(default)
+        }),
+        // 未設定は既定でよい。設定されているのに読めない (NotUnicode) のは
+        // 設定ミスなので、黙って未設定と同じ扱いにしない。
+        Err(std::env::VarError::NotPresent) => tracing_subscriber::EnvFilter::new(default),
+        Err(e) => {
+            eprintln!("could not read RUST_LOG, falling back to {default}: {e}");
+            tracing_subscriber::EnvFilter::new(default)
+        }
     };
-    tracing_subscriber::fmt().with_max_level(level).init();
+    tracing_subscriber::fmt().with_env_filter(filter).init();
 
     let cfg: Config = {
         use std::io::Read;
@@ -273,14 +291,16 @@ async fn webhook(
         Ok(msg) => Some(msg),
         Err(why) => {
             match &why {
-                // 通知対象にしていない action。error! で出すと本物の失敗が埋もれる。
+                // 通知対象にしていない action。error! で出すと本物の失敗が
+                // 埋もれるが、debug だと「なぜ飛ばなかったか」を後から追えない。
                 message::NotRendered::Skipped(_) => {
-                    debug!("not notified ({why}). link = {}", payload.url());
+                    info!(reason = %why, link = %payload.url(), "not notified");
                 }
                 message::NotRendered::Unexpected(_) => {
                     error!(
-                        "GitHub payload -> slack::Message failed ({why}). link = {}",
-                        payload.url()
+                        reason = %why,
+                        link = %payload.url(),
+                        "GitHub payload -> slack::Message failed"
                     );
                 }
             }

--- a/src/slack.rs
+++ b/src/slack.rs
@@ -86,6 +86,43 @@ fn should_retry(payload: &MessagePayload, error: &str) -> bool {
 struct PostResponse {
     ok: bool,
     error: Option<String>,
+    /// Slack は `ok: true` でも警告を返す。`missing_charset` のように
+    /// こちらの送り方の問題を指すものがあるので捨てない。
+    warning: Option<String>,
+    response_metadata: Option<ResponseMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseMetadata {
+    #[serde(default)]
+    warnings: Vec<String>,
+}
+
+impl PostResponse {
+    /// `warning` と `response_metadata.warnings` を混ぜて返す。
+    ///
+    /// 同じ内容が両方に入ることがあるので重複は落とす。
+    fn warnings(&self) -> Vec<&str> {
+        let flat = self
+            .warning
+            .as_deref()
+            .into_iter()
+            .flat_map(|w| w.split(','))
+            .map(str::trim);
+        let listed = self
+            .response_metadata
+            .as_ref()
+            .into_iter()
+            .flat_map(|m| m.warnings.iter().map(String::as_str));
+
+        let mut out: Vec<&str> = Vec::new();
+        for w in flat.chain(listed) {
+            if !w.is_empty() && !out.contains(&w) {
+                out.push(w);
+            }
+        }
+        out
+    }
 }
 
 async fn post(
@@ -117,6 +154,19 @@ async fn post(
         .map_err(|e| PostError::Request(format!("could not read response: {e}")))?;
 
     debug!("{body:?}");
+
+    // ok: true でも返ってくる。こちらの送り方の問題を教えてくれるので出す。
+    let warnings = body.warnings();
+    if !warnings.is_empty() {
+        // channel ごとに投稿するので、どの宛先の警告か分からないと追えない。
+        // join せず配列のまま出す。確保が増えるし、構造も失われる
+        warn!(
+            channel = %payload.channel,
+            ok = body.ok,
+            warnings = ?warnings,
+            "Slack returned warnings"
+        );
+    }
 
     if body.ok {
         Ok(())
@@ -394,40 +444,41 @@ impl Message {
 
         match post(&client, base, token, &payload, POST_BUDGET).await {
             Ok(()) => {
-                debug!("POST ok ({})", payload.body_kind());
+                // どの表現で通ったかは、表現を変えたときの答え合わせに要る。
+                info!(channel, body = payload.body_kind(), "POST ok");
                 return;
             }
             // リクエスト自体の失敗は payload を変えても直らない。
             // 再送すると待ち時間も倍になるので諦める。
             Err(PostError::Request(e)) => {
-                error!("POST to {channel}: {e}");
+                error!(channel, error = %e, "POST failed");
                 return;
             }
             Err(PostError::Api(e)) => {
                 if !should_retry(&payload, &e) {
-                    error!("POST to {channel}: {e}");
+                    error!(channel, error = %e, "POST failed");
                     return;
                 }
 
                 // markdown ブロックが attachment 内で使えるか、本文が上限を
                 // 超えたかはこちらで判定できない。blocks 由来と思われる
                 // エラーなら、従来の表現 (attachment の text) で再送する。
-                warn!("POST to {channel} rejected ({e}); retrying without markdown blocks");
+                warn!(channel, error = %e, "POST rejected; retrying without markdown blocks");
             }
         }
 
         // 再送も予算の中で行う。取り直すと webhook の締め切りを超えて
         // GitHub が再送し、通知が重複する
         let Some(left) = remaining(deadline, Instant::now()) else {
-            error!("POST to {channel} (fallback): out of budget");
+            error!(channel, "POST fallback skipped: out of budget");
             return;
         };
 
         let fallback = payload.into_text_fallback();
         match post(&client, base, token, &fallback, left).await {
-            // 退避が起きたこと自体が知りたい情報なので debug では埋もれる
-            Ok(()) => info!("POST ok (fallback: {})", fallback.body_kind()),
-            Err(e) => error!("POST to {channel} (fallback): {e}"),
+            // 届いてはいるが本来の表現が拒否された、という degraded success。
+            Ok(()) => warn!(channel, body = fallback.body_kind(), "POST ok (fallback)"),
+            Err(e) => error!(channel, error = %e, "POST failed (fallback)"),
         }
     }
 }
@@ -787,6 +838,35 @@ mod tests {
             "blocks で送っていない: {}",
             got[0]
         );
+    }
+
+    /// Slack の警告を取りこぼさないこと。
+    ///
+    /// `warning` と `response_metadata.warnings` の両方に返ることがあり、
+    /// 同じ内容が重複する。
+    #[test]
+    fn warnings_are_merged_and_deduped() {
+        let res: PostResponse = serde_json::from_value(serde_json::json!({
+            "ok": true,
+            "warning": "missing_charset,superfluous_charset",
+            "response_metadata": { "warnings": ["missing_charset"] }
+        }))
+        .expect("deserialize できない");
+
+        assert_eq!(res.warnings(), ["missing_charset", "superfluous_charset"]);
+    }
+
+    /// 警告が無い応答も読めること。
+    ///
+    /// `warning` を必須にすると、正常な応答で deserialize が落ちて
+    /// 投稿できたのに失敗扱いになる。
+    #[test]
+    fn response_without_warnings_is_accepted() {
+        let res: PostResponse = serde_json::from_value(serde_json::json!({ "ok": true }))
+            .expect("deserialize できない");
+
+        assert!(res.ok);
+        assert!(res.warnings().is_empty(), "{:?}", res.warnings());
     }
 
     /// blocks 由来のエラーなら、従来の表現で再送すること。


### PR DESCRIPTION
ログレベルは `--debug` の有無で `DEBUG` か `WARN` のどちらかに固定されている。`WARN` 側では `info!` と `debug!` のログが捨てられるので、投稿がどの表現で通ったのか、通知しなかったのはなぜかがログに残らない。

- ログレベルを `RUST_LOG` で上書きできるようにし、既定を `info` にする。`--debug` は `debug` のショートカットとして残す。解釈できないときと、設定されているのに読めないときは黙って既定に落ちず stderr に出す
- `POST ok` を `info!` に上げ、どの表現で通ったかがログに残るようにする
- 通知対象にしていない action を飛ばした理由も `info!` で残す。`debug` だと「なぜ飛ばなかったか」を後から追えない
- 退避が成功したときは `warn!` にする。届いてはいるが本来の表現が拒否されたという degraded success で、`WARN` より低いレベルではログに出ない
- `channel` / `error` / `body` / `reason` を structured field にする。ログの検索で絞り込める
- Slack の応答の `warning` と `response_metadata.warnings` を捨てていたので、`channel` を添えてログに出す
- `RUST_LOG` を `.env.example` / `docker-compose.yml` / README に追加する。設定できても経路が無いと使えない。compose 経由では未設定でも空文字が入り、空の `EnvFilter` は何も出さなくなるので、空は未設定として扱う
