### PR TITLE
fix: log the value Slack warned about

### DIFF
--- a/src/slack.rs
+++ b/src/slack.rs
@@ -153,10 +153,20 @@ async fn post(
     if !warnings.is_empty() {
         // channel ごとに投稿するので、どの宛先の警告か分からないと追えない。
         // join せず配列のまま出す。確保が増えるし、構造も失われる
+        //
+        // 送った値も残す。Slack は切った後の値も理由も返さないので、警告の
+        // 名前だけでは何がどう削られたのか分からない。`username_too_long` は
+        // 表示名が切られたことしか言わず、どの display_name だったかは
+        // channel からも一意に決まらない。
         warn!(
             channel = %payload.channel,
             ok = body.ok,
             warnings = ?warnings,
+            username = payload.username.as_deref().unwrap_or(""),
+            // 上限がドキュメントに無いので、文字数とバイト数の両方を出す。
+            // どちらで切られているかはログを並べて初めて分かる
+            username_chars = payload.username.as_deref().map_or(0, |u| u.chars().count()),
+            username_bytes = payload.username.as_deref().map_or(0, str::len),
             "Slack returned warnings"
         );
     }


### PR DESCRIPTION
Slack は `ok: true` でも警告を返すが、ログには警告の名前と channel しか出していない。`username_too_long` のように「送った値が長すぎて切った」という警告では、**何がどう削られたのか分からない**。Slack は切った後の値も上限も返さないので、送った値はこちらで残すしかない。

`username` は rule の `display_name` なので、channel からも一意に決まらない（同じ channel に別の `display_name` が付いた rule がある）。

送った `username` と、その文字数・バイト数を足す。

```
Slack returned warnings channel=example ok=true warnings=["username_too_long"]
  username="あいうえおかきく" username_chars=8 username_bytes=24
```

`username` の上限は Slack のドキュメントに無く、`chat.postMessage` のリファレンスにも `username_too_long` の記載がない。文字数とバイト数の両方を出しておけば、並べたときにどちらで切られているかが分かる。
