### PR TITLE
chore: drop the renovate config duplicated from the shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,30 +7,12 @@
   "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
-      "groupName": "Rust",
-      "groupSlug": "rust",
-      "matchPackageNames": [
-        "rust",
-        "ghcr.io/sksat/cargo-chef-docker"
-      ]
-    },
-    {
       "groupName": "sentry-rust",
       "groupSlug": "sentry",
       "matchPackageNames": [
         "sentry",
         "sentry-actix"
       ]
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^rust-toolchain(\\.toml)?$/"],
-      "matchStrings": ["channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
同じ `rust-toolchain` の 1 行に対して Renovate の PR が 2 本出ている (#252 と #264)。diff は `channel = "1.97.1"` → `"1.98.1"` で完全に同一。

Dependency Dashboard (#145) を見ると、この 1 行を **3 つ**が別々に拾っている。

- `regex` manager が 2 インスタンス — `github>arkedge/renovate-config` の `rust-toolchain.json5` と、この repo の `renovate.json` に書かれた同じ内容のもの
- 組み込みの `rust-toolchain` manager — 同じ `(^|/)rust-toolchain(\.toml)?$` を見る

この repo 側の定義はプリセットの重複なので消す。`groupName: "Rust"` の packageRule も同様で、プリセットの `cargo-chef-docker.json5` に同じものがある。

これだけでは PR は 1 本にならない。残るのはプリセットの regex manager と組み込み manager で、datasource が違うため別の依存として扱われる。組み込み manager がある以上プリセットの regex manager は要らないので、そちらは arkedge/renovate-config 側で消すのが筋。

なお #252 と #264 はどちらも今はマージできない。`ghcr.io/sksat/cargo-chef-docker` に `1.98.1-bookworm` が無く (404、現行は `1.97.1-bookworm`)、rust-toolchain だけが上がって base image とずれる。
